### PR TITLE
use 'console.error' if 'logger' isn't established during uncaughtExce…

### DIFF
--- a/index.js
+++ b/index.js
@@ -918,7 +918,11 @@ process.on('unhandledRejection', function (reason, p) {
     throw reason;
 });
 process.on('uncaughtException', function ( e ) {
-    logger.error( e );
+    if (logger) {
+        logger.error( e );
+    } else {
+        console.error( e );
+    }
     process.exit( -1 );
 });
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ziti-browzer-bootstrapper",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "compatibleControllerVersion": ">=0.27.9",
   "description": "Ziti BrowZer Bootstrapper -- providing Ziti network access into Dark web server",
   "main": "index.js",


### PR DESCRIPTION
…ption